### PR TITLE
Restore and Dump structure scripts fixed to return proper PHP error

### DIFF
--- a/bin/dump-structure
+++ b/bin/dump-structure
@@ -1,7 +1,7 @@
 #!/bin/sh
 echo "Creating class migrations... "
 retval=`php vendor/tpetb/pimcore-sak/src/MigrateCommit.php;`
-if [ $retval ]; then
+if [ "$retval" ]; then
         echo "Migration failed. PHP Output:";
         echo $retval;
         exit 1

--- a/bin/restore-structure
+++ b/bin/restore-structure
@@ -1,7 +1,7 @@
 #!/bin/sh
 echo "Migrating classess... "
 retval=`php vendor/tpetb/pimcore-sak/src/MigrateCheckout.php`
-if [ $retval ]; then
+if [ "$retval" ]; then
         echo "Migration failed. PHP output:"
         echo $retval;
         exit 1;


### PR DESCRIPTION
Restore and Dump structure scripts fixed to return proper PHP error instead of '[: too many arguments'